### PR TITLE
Fix drawing vertice values

### DIFF
--- a/Problems/GuardSchedule/FirstGuardScheduleSnapshotCreator.cs
+++ b/Problems/GuardSchedule/FirstGuardScheduleSnapshotCreator.cs
@@ -27,7 +27,7 @@ public class FirstGuardScheduleSnapshotCreator(GuardScheduleInputData inputData)
             x = (int)(centerX + radiusX * Math.Cos(angle));
             y = (int)(centerY + radiusY * Math.Sin(angle));
 
-            vertices.Add(new GraphVertex(x, y, r.Next(1, 30).ToString()));
+            vertices.Add(new GraphVertex(x, y, inputData.Pathway.Vertices[vertexIndex].ToString()));
         }
 
         for (int vertexIndex = 0; vertexIndex < verticeAmount; vertexIndex++)


### PR DESCRIPTION
Changes in FirstGuardScheduleSnapshotCreator when it was taking random numbers before instead of vertice values from json.