### PR TITLE
Remove activating vertex in Carrier Assginment

### DIFF
--- a/Components/Pages/Input/InputMethods/GraphCreatorInput/GraphCreatorProblemSettingsProvider.cs
+++ b/Components/Pages/Input/InputMethods/GraphCreatorInput/GraphCreatorProblemSettingsProvider.cs
@@ -27,6 +27,7 @@ public static class GraphCreatorProblemSettingsProvider
                     | GraphInputValidatorModes.ShouldHave3Vertices
                     | GraphInputValidatorModes.ShouldHaveSpecialVertex
                     | GraphInputValidatorModes.EveryVertexShouldHaveValue
+                    | GraphInputValidatorModes.VerticesShouldBeOnDifferentLines
         };
     }
 
@@ -41,6 +42,7 @@ public static class GraphCreatorProblemSettingsProvider
             Modes = GraphInputValidatorModes.EverythingConnected
                     | GraphInputValidatorModes.ShouldHave3Vertices
                     | GraphInputValidatorModes.ShouldHaveSpecialVertex
+                    | GraphInputValidatorModes.VerticesShouldBeOnDifferentLines
         };
     }
 }

--- a/Components/Pages/Input/InputMethods/GraphCreatorInput/Validator/GraphInputValidator.cs
+++ b/Components/Pages/Input/InputMethods/GraphCreatorInput/Validator/GraphInputValidator.cs
@@ -41,8 +41,21 @@ public static class GraphInputValidator
         if (modes.HasFlag(GraphInputValidatorModes.EverythingConnected))
             if (!CheckEverythingConnected(graphInputData, isDirected))
                 errors.Add(new GraphValidatorError("Wszystkie wierzchołki muszą być połączone ze sobą."));
+        if (modes.HasFlag(GraphInputValidatorModes.VerticesShouldBeOnDifferentLines))
+            if (!CheckVerticesOnDifferentLines(graphInputData))
+                errors.Add(new GraphValidatorError("Wierzchołki nie mogą być wszystkie na jednej prostej."));
 
         return errors;
+    }
+
+    private static bool CheckVerticesOnDifferentLines(ProblemGraphInputData graphInputData)
+    {
+        var vertices = graphInputData.Vertices;
+        var xValues = vertices.Select(v => v.X).ToList();
+        var yValues = vertices.Select(v => v.Y).ToList();
+        Console.WriteLine(xValues.Distinct().Count());
+        Console.WriteLine(yValues.Distinct().Count());
+        return xValues.Distinct().Count() > 1 && yValues.Distinct().Count() > 1;
     }
 
     private static bool CheckEveryVertexHaveValue(ProblemGraphInputData graphInputData)

--- a/Components/Pages/Input/InputMethods/GraphCreatorInput/Validator/GraphInputValidatorModes.cs
+++ b/Components/Pages/Input/InputMethods/GraphCreatorInput/Validator/GraphInputValidatorModes.cs
@@ -8,5 +8,6 @@ public enum GraphInputValidatorModes
     EverythingConnected = 4,
     ShouldHave3Vertices = 8,
     ShouldHaveSpecialVertex = 16,
-    EveryVertexShouldHaveValue = 32
+    EveryVertexShouldHaveValue = 32,
+    VerticesShouldBeOnDifferentLines = 64
 }

--- a/Problems/FenceTransport/CarrierAssignmentResolver.cs
+++ b/Problems/FenceTransport/CarrierAssignmentResolver.cs
@@ -138,8 +138,6 @@ public class CarrierAssignmentResolver : ProblemResolver<FenceTransportInputData
 
                 var from = graphData.Vertices.IndexOf(edge.From);
                 var to = graphData.Vertices.IndexOf(edge.To);
-                ActivateVertex(from);
-                ActivateVertex(to);
 
                 if (from >= 0 && from < data.FrontCarrierNumber)
                     problemRecreationCommands?.Add(new ChangeVertexImageCommand(from,
@@ -167,11 +165,6 @@ public class CarrierAssignmentResolver : ProblemResolver<FenceTransportInputData
     {
         problemRecreationCommands?.Add(new ChangeVertexStateCommand(graphData.Vertices.Count - 2, GraphStates.Special));
         problemRecreationCommands?.Add(new ChangeVertexStateCommand(graphData.Vertices.Count - 1, GraphStates.Special));
-    }
-
-    private void ActivateVertex(int index)
-    {
-        problemRecreationCommands?.Add(new ChangeVertexStateCommand(index, GraphStates.Active));
     }
 
     private void ChangeEdge(int index, GraphEdge edge)

--- a/Problems/FenceTransport/CarrierAssignmentResolver.cs
+++ b/Problems/FenceTransport/CarrierAssignmentResolver.cs
@@ -138,6 +138,8 @@ public class CarrierAssignmentResolver : ProblemResolver<FenceTransportInputData
 
                 var from = graphData.Vertices.IndexOf(edge.From);
                 var to = graphData.Vertices.IndexOf(edge.To);
+                ActivateVertex(from);
+                ActivateVertex(to);
 
                 if (from >= 0 && from < data.FrontCarrierNumber)
                     problemRecreationCommands?.Add(new ChangeVertexImageCommand(from,
@@ -165,6 +167,11 @@ public class CarrierAssignmentResolver : ProblemResolver<FenceTransportInputData
     {
         problemRecreationCommands?.Add(new ChangeVertexStateCommand(graphData.Vertices.Count - 2, GraphStates.Special));
         problemRecreationCommands?.Add(new ChangeVertexStateCommand(graphData.Vertices.Count - 1, GraphStates.Special));
+    }
+
+    private void ActivateVertex(int index)
+    {
+        problemRecreationCommands?.Add(new ChangeVertexStateCommand(index, GraphStates.Active));
     }
 
     private void ChangeEdge(int index, GraphEdge edge)

--- a/Problems/FenceTransport/ConvexHullResolver.cs
+++ b/Problems/FenceTransport/ConvexHullResolver.cs
@@ -78,7 +78,9 @@ public class ConvexHullResolver : ProblemResolver<FenceTransportInputData, Conve
     {
         for (var i = 0; i < angles.Count; i++)
         for (var j = i + 1; j < angles.Count; j++)
-            if (angles[i] > angles[j] || (angles[i] == angles[j] && vertices[i].X > vertices[j].X))
+            if (angles[i] > angles[j] || 
+                (angles[i] == angles[j] && vertices[i].X > vertices[j].X) ||
+                (angles[i] == angles[j] && vertices[i].X == vertices[j].X && vertices[i].Y > vertices[j].Y))
             {
                 var temp = angles[i];
                 angles[i] = angles[j];


### PR DESCRIPTION
- usunięto aktywowanie wierzchołków, aby na tragarzach lepiej było widać napis (ich indeks)
- dodanie warunku aby sprawdzało, czy wierzchołki nie są na jednej prostej
- poprawiono sortowanie w ConvexHull aby brało pod uwagę wartość Y, jeżeli kąt i wartość X są takie same